### PR TITLE
Develop Analog pin interface for beaglebone black

### DIFF
--- a/embedded/drivers/CMakeLists.txt
+++ b/embedded/drivers/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(DriversLib VERSION 0.1 LANGUAGES CXX)
 
-add_library(drivers src/i2c.cpp src/serial.cpp)
+add_library(drivers src/i2c.cpp src/serial.cpp src/analog.cpp)
 
 target_include_directories(drivers PUBLIC include)
 

--- a/embedded/drivers/README.md
+++ b/embedded/drivers/README.md
@@ -30,3 +30,29 @@ int write_data(uint8_t, uint8_t val); // Write data to a register
 int read_data(uint8_t *buff, int size); //Read data from a device
 uint8_t read_from_reg(uint8_t reg); // Read data from a specific register
 ```
+
+## Analog class
+
+This class represents a single analog pin on the Beaglebone Black.
+
+### Getting started
+
+To create a new analog pin object, call the constructor `Analog::Analog`. This constructor takes the pin's number as well as a scale factor to multiply the measured voltage by.
+
+```c++
+Analog::Analog(int pin, float scale)
+```
+
+Then, call the `Analog::begin` function to initialize the resources required to read from the analog pin.
+
+### Reading a pin
+
+To read from an analog pin, call the `Analog::readPin` function. This will read the raw value from the BBB ADC and convert it into a voltage. This voltage is then multiplied by the devices scale factor.
+
+```c++
+float readPin();
+```
+
+### The scale factor
+
+Since the BBB adc has a 1.8 volt maximum threshold, the voltage output from devices that exceed this range will need to be divided down by some factor. The `scale` variable represents this factor.

--- a/embedded/drivers/README.md
+++ b/embedded/drivers/README.md
@@ -31,23 +31,31 @@ int read_data(uint8_t *buff, int size); //Read data from a device
 uint8_t read_from_reg(uint8_t reg); // Read data from a specific register
 ```
 
-## Analog class
+## AnalogPin class
 
 This class represents a single analog pin on the Beaglebone Black.
 
 ### Getting started
 
-To create a new analog pin object, call the constructor `Analog::Analog`. This constructor takes the pin's number as well as a scale factor to multiply the measured voltage by.
+To create a new analog pin object, call the constructor `AnalogPin::AnalogPin`. This constructor takes the pin's number as well as a scale factor to multiply the measured voltage by.
 
 ```c++
-Analog::Analog(int pin, float scale)
+AnalogPin::AnalogPin(int pin, float scale)
 ```
 
 Then, call the `Analog::begin` function to initialize the resources required to read from the analog pin.
 
+Example:
+```c++
+AnalogPin potentiometerIn = AnalogPin(7, 1.0);
+if (!potentiometerIn.begin()) {
+    printf("Potentiometer in pin failed to begin!\n\r");
+}
+```
+
 ### Reading a pin
 
-To read from an analog pin, call the `Analog::readPin` function. This will read the raw value from the BBB ADC and convert it into a voltage. This voltage is then multiplied by the devices scale factor.
+To read from an analog pin, call the `AnalogPin::readPin` function. This will read the raw value from the BBB ADC and convert it into a voltage. This voltage is then multiplied by the devices scale factor.
 
 ```c++
 float readPin();

--- a/embedded/drivers/include/analog.h
+++ b/embedded/drivers/include/analog.h
@@ -6,6 +6,7 @@ class Analog {
  private:
   int fd;
   uint16_t scale;
+  int pin;
 
  public:
   Analog(int pin, int scale);

--- a/embedded/drivers/include/analog.h
+++ b/embedded/drivers/include/analog.h
@@ -13,7 +13,7 @@ class Analog {
   ~Analog();
   bool begin();
   bool isOpen();
-  float read();
+  float readPin();
 };
 
 #endif

--- a/embedded/drivers/include/analog.h
+++ b/embedded/drivers/include/analog.h
@@ -2,15 +2,15 @@
 #define __ANALOG_H__
 #include <stdint.h>
 
-class Analog {
+class AnalogPin {
  private:
   int fd;
-  float scale;
+  float scale_factor;
   int pin;
 
  public:
-  Analog(int pin, float scale);
-  ~Analog();
+  AnalogPin(int pin, float scale_factor);
+  ~AnalogPin();
   bool begin();
   bool isOpen();
   float readPin();

--- a/embedded/drivers/include/analog.h
+++ b/embedded/drivers/include/analog.h
@@ -1,0 +1,18 @@
+#ifndef __ANALOG_H__
+#define __ANALOG_H__
+#include <stdint.h>
+
+class Analog {
+ private:
+  int fd;
+  uint16_t scale;
+
+ public:
+  Analog(int pin, int scale);
+  ~Analog();
+  bool begin();
+  bool isOpen();
+  float read();
+};
+
+#endif

--- a/embedded/drivers/include/analog.h
+++ b/embedded/drivers/include/analog.h
@@ -5,11 +5,11 @@
 class Analog {
  private:
   int fd;
-  uint16_t scale;
+  float scale;
   int pin;
 
  public:
-  Analog(int pin, int scale);
+  Analog(int pin, float scale);
   ~Analog();
   bool begin();
   bool isOpen();

--- a/embedded/drivers/src/analog.cpp
+++ b/embedded/drivers/src/analog.cpp
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include <fstream>
 #include <iostream>
 
 #define NUM_ANALOG_PINS 7
@@ -14,12 +15,12 @@ Analog::Analog(int pin, int scale) {
   this->pin = pin;
 }
 
-Analog::~Analog() {}
+Analog::~Analog() { close(this->fd); }
 
 bool Analog::begin() {
   char filePath[49];
 
-  if (this->pin < 0 && this->pin >= NUM_ANALOG_PINS) {
+  if (this->pin < 0 || this->pin >= NUM_ANALOG_PINS) {
     std::cout << "Pin number not in range\n";
     return false;
   }
@@ -32,6 +33,12 @@ bool Analog::begin() {
   return true;
 }
 
-bool Analog::isOpen() { return true; }
+bool Analog::isOpen() { return this->fd > 0; }
 
-float Analog::read() { return 0; }
+float Analog::readPin() {
+  uint16_t val;
+
+  read(this->fd, &val, 2);
+
+  return (1.8 / (float)4096) * (float)val;
+}

--- a/embedded/drivers/src/analog.cpp
+++ b/embedded/drivers/src/analog.cpp
@@ -8,9 +8,13 @@
 #include <iostream>
 
 #define NUM_ANALOG_PINS 7
-#define PIN_FILE_PATH "/sys/bus/iio/devices/iio:device0/in_voltage%d_raw"
 #define BBB_ADC_RANGE 1.8
 #define BBB_ADC_RESOLUTION 4096.0
+
+#define PIN_FILE_PATH "/sys/bus/iio/devices/iio:device0/in_voltage%d_raw"
+
+/* Copies the filepath to a given pin into a specified buffer */
+#define PIN_NUMBER_TO_FILEPATH(buff, pin) (sprintf(buff, PIN_FILE_PATH, pin))
 
 AnalogPin::AnalogPin(int pin, float scale_factor) {
   this->scale_factor = scale_factor;
@@ -32,7 +36,7 @@ bool AnalogPin::begin() {
     return false;
   }
 
-  sprintf(filePath, PIN_FILE_PATH, this->pin);
+  PIN_NUMBER_TO_FILEPATH(filePath, this->pin);
   this->fd = open(filePath, O_RDONLY);
   if (!this->isOpen()) {
     std::cout << "Failed to open file\n";
@@ -48,7 +52,7 @@ float AnalogPin::readPin() {
   float val;
 
   // need to read this as a char array for some reason
-  read(this->fd, &raw[0], 4);
+  read(this->fd, raw, 4);
   val = atof(raw);
 
   // reset the file pointer to start from the beginning on next read

--- a/embedded/drivers/src/analog.cpp
+++ b/embedded/drivers/src/analog.cpp
@@ -1,15 +1,36 @@
 #include "analog.h"
 
 #include <fcntl.h>
+#include <stdio.h>
 #include <unistd.h>
 
 #include <iostream>
 
-Analog::Analog(int pin, int scale) {}
+#define NUM_ANALOG_PINS 7
+#define PIN_FILE_PATH "/sys/bus/iio/devices/iio:device0/in_voltage%d_raw"
+
+Analog::Analog(int pin, int scale) {
+  this->scale = scale;
+  this->pin = pin;
+}
 
 Analog::~Analog() {}
 
-bool Analog::begin() {}
+bool Analog::begin() {
+  char filePath[49];
+
+  if (this->pin < 0 && this->pin >= NUM_ANALOG_PINS) {
+    std::cout << "Pin number not in range\n";
+    return false;
+  }
+  sprintf(filePath, PIN_FILE_PATH, this->pin);
+  this->fd = open(filePath, O_RDONLY);
+  if (!this->isOpen()) {
+    std::cout << "Failed to open file\n";
+    return false;
+  }
+  return true;
+}
 
 bool Analog::isOpen() { return true; }
 

--- a/embedded/drivers/src/analog.cpp
+++ b/embedded/drivers/src/analog.cpp
@@ -36,9 +36,15 @@ bool Analog::begin() {
 bool Analog::isOpen() { return this->fd > 0; }
 
 float Analog::readPin() {
-  uint16_t val;
+  char raw[4];
+  float val;
 
-  read(this->fd, &val, 2);
+  // need to read this as a char array for some reason
+  read(this->fd, &raw[0], 4);
+  val = atof(raw);
 
-  return (1.8 / (float)4096) * (float)val;
+  // reset the file pointer to start from the beginning on next read
+  lseek(this->fd, 0, SEEK_SET);
+
+  return (1.8 / 4096.0) * val;
 }

--- a/embedded/drivers/src/analog.cpp
+++ b/embedded/drivers/src/analog.cpp
@@ -10,7 +10,7 @@
 #define NUM_ANALOG_PINS 7
 #define PIN_FILE_PATH "/sys/bus/iio/devices/iio:device0/in_voltage%d_raw"
 
-Analog::Analog(int pin, int scale) {
+Analog::Analog(int pin, float scale) {
   this->scale = scale;
   this->pin = pin;
 }
@@ -46,5 +46,5 @@ float Analog::readPin() {
   // reset the file pointer to start from the beginning on next read
   lseek(this->fd, 0, SEEK_SET);
 
-  return (1.8 / 4096.0) * val;
+  return (1.8 / 4096.0) * val * this->scale;
 }

--- a/embedded/drivers/src/analog.cpp
+++ b/embedded/drivers/src/analog.cpp
@@ -1,0 +1,16 @@
+#include "analog.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <iostream>
+
+Analog::Analog(int pin, int scale) {}
+
+Analog::~Analog() {}
+
+bool Analog::begin() {}
+
+bool Analog::isOpen() { return true; }
+
+float Analog::read() { return 0; }


### PR DESCRIPTION
Since we have a smaller list of analog i/o for the solar car, we will not be using an external ADC. This means that all of our analog inputs will be used to read i/o instead. This task focuses on developing an interface for us to read these pins in our main program.


The raw values can be read from `/sys/bus/iio/devices/iio:device0/in_voltage<pin>_raw`
There are 7 total analog pins on the beaglebone black.
The BBB adc has a range of 1.8V and is read as a 12 bit number.
We will also need to account for a scaling factor that will be determined by low voltage